### PR TITLE
 If system dotnet version is higher than dotnetcore2 runtime one, use that.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,6 @@ install_requires =
     keyring >= 16.0
     dotnetcore2; sys_platform != 'win32' and python_version >= '3.0'
     requests >= 2.20.0
-    packaging
 
 [options.packages.find]
 where=src

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     keyring >= 16.0
     dotnetcore2; sys_platform != 'win32' and python_version >= '3.0'
     requests >= 2.20.0
+    packaging
 
 [options.packages.find]
 where=src

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v0.1.20"
+    + "v0.1.22"
     + "/Microsoft.NuGet.CredentialProvider.tar.gz"
 )
 

--- a/src/artifacts_keyring/plugin.py
+++ b/src/artifacts_keyring/plugin.py
@@ -33,8 +33,8 @@ class CredentialProvider(object):
             self.exe = [tool_path]
         else:
             try:
-                sys_version = tuple(int(i) for i in 
-                    subprocess.check_output("dotnet --version").decode().strip().partition("-")[0].split("."))
+                sys_version = tuple(int(i) for i in
+                    subprocess.check_output(["dotnet", "--version"]).decode().strip().partition("-")[0].split("."))
             except Exception:
                 sys_version = None
             try:


### PR DESCRIPTION
The dotenetcore2-packaged runtime fails on Ubuntu 19+, claiming it
doesn't find a supported libssl. dotnetcore 3 is not available on pypi (#20).
This PR at allows users to work around the issue by installing
dotnet-sdk-3.1 manually in their system, artifacts-keyring will give
precedence to a newer dotnet system binary.

Note that artifacts-credprovider actually *recommends* using dotnetcore v3.1:
https://github.com/Microsoft/artifacts-credprovider/#prerequisites