### PR TITLE
Bump keyring version to 0.3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = artifacts-keyring
-version = 0.2.11.Preview
+version = 0.3.0
 author = Microsoft Corporation
 url = https://github.com/Microsoft/artifacts-keyring
 license_file = LICENSE.txt

--- a/src/artifacts_keyring/__init__.py
+++ b/src/artifacts_keyring/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "0.2.11.Preview"
+__version__ = "0.3.0"
 
 import json
 import subprocess


### PR DESCRIPTION
Releasing keyring version 0.3.0 after preview version works fine.

Releasing fix for the following bug:
https://dev.azure.com/mseng/AzureDevOps/_workitems/edit/1669777/