### PR TITLE
Bump version of credential provider downloaded during setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = artifacts-keyring
-version = 0.3.2
+version = 0.3.3
 author = Microsoft Corporation
 url = https://github.com/Microsoft/artifacts-keyring
 license_file = LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v0.1.22"
+    + "v1.0.0"
     + "/Microsoft.NuGet.CredentialProvider.tar.gz"
 )
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v1.0.0"
+    + "v1.0.1"
     + "/Microsoft.NuGet.CredentialProvider.tar.gz"
 )
 

--- a/src/artifacts_keyring/__init__.py
+++ b/src/artifacts_keyring/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 import json
 import subprocess


### PR DESCRIPTION
This PR changes version of artifacts-credprovider from `0.1.22` to `1.0.0`. This fixes some vulnerable dependencies, particularly `NuGet.Protocol` and `Newtonsoft.Json`