### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v1.0.7"
+    + "v1.0.8"
     + "/Microsoft.NuGet.CredentialProvider.tar.gz"
     )
 

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v1.0.1"
+    + "v1.0.7"
     + "/Microsoft.NuGet.CredentialProvider.tar.gz"
-)
+    )
 
 
 def download_credential_provider(root):


### PR DESCRIPTION
updating .Net package for dotnet security update for vulnerability [CVE-2022-41032](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-41032) .

Microsoft is releasing this security advisory to provide information about a vulnerability in .NET 7.0.0-rc, .NET 6.0, .NET Core 3.1, and NuGet (NuGet.exe, NuGet.Commands, NuGet.CommandLine, NuGet.Protocol). This advisory also provides guidance on what developers can do to update their applications to remove this vulnerability.


Newtonsoft.Json prior to version 13.0.1 is vulnerable to Insecure Defaults due to improper handling of expressions with high nesting level that lead to StackOverFlow exception or high CPU and RAM usage. Exploiting this vulnerability results in Denial Of Service (DoS). The serialization and deserialization path have different properties regarding the issue. Deserializing methods (like `JsonConvert.DeserializeObject`) will process the input that results in burning the CPU, allocating memory, and consuming a thread of execution. Quite high nesting level (>10kk, or 9.5MB of `{a:{a:{...` input) is needed to achieve the latency over 10 seconds, depending on the hardware. Serializing methods (like `JsonConvert.Serialize` or `JObject.ToString`) will throw StackOverFlow exception with the nesting level of around 20k. To mitigate the issue one either need to update Newtonsoft.Json to 13.0.1 or set `MaxDepth` parameter in the `JsonSerializerSettings`. This can be done globally with the following statement. After that the parsing of the nested input will fail fast with `Newtonsoft.Json.JsonReaderException`: ``` JsonConvert.DefaultSettings = () => new JsonSerializerSettings { MaxDepth = 128 }; ``` Repro code: ``` //Create a string representation of an highly nested object (JSON serialized) int nRep = 25000; string json = string.Concat(Enumerable.Repeat("{a:", nRep)) + "1" + string.Concat(Enumerable.Repeat("}", nRep)); //Parse this object (leads to high CPU/RAM consumption) var parsedJson = JsonConvert.DeserializeObject(json); // Methods below all throw stack overflow with nRep around 20k and higher // string a = parsedJson.ToString(); // string b = JsonConvert.SerializeObject(parsedJson); ``` **Note the original statement about the problem only affecting IIS applications is misleading.** Any application is affected, however the IIS has a behavior that stops restarting the instance after some time resulting in a harder-to-fix DoS.