### PR TITLE
Ask for minimal output. And update documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,49 @@ find credentials.
 
 ## Installation
 
-To install this package, run the following `pip` command:
+As of version 23.1 Pip can use the `keyring` as a command line application in addition to importing it as a python library.
+This allows one to install keyring such that it can be found on the PATH.
+Go to [Pip's Authentication documentation](https://pip.pypa.io/en/stable/topics/authentication/#) for up-to-date information on all Pip's authentication abilities.
+
+The CLI is a one time installation, assuming one of the following is true:
+- The `virtualenv` cli/library is (indirectly) used to create new virtual environments.
+- You only use Python versions new enough that the following returns 23.1 or higher.
+  ```
+  python -m venv .venv
+  .venv/Scripts/pip.exe --version
+  ```
+
+### Common
+If you don't want to/can supply the private index url for each command there are two alternatives:
+- run `pip config set global.index-url <your URL here>`. To configure once for all users add the `--global` flag.
+- Set environment variable `PIP_INDEX_URL` to you url.
+
+The same applies to extra index urls. `PIP_EXTRA_INDEX_URL` is the name of the environment variable and `global.extra-index-url` is the value to provide `pip config set`.
+
+### Install via pipx as a CLI
+```powershell
+#powershell
+python -m venv temp
+. ./Scripts/activate.ps1
+$global = Read-Host "To install for current user only, press enter. To install for all users, which requires admin permissions, type '--global' (no quotes)"
+pip config set global.keyring-provider subprocess $global
+pip install pipx --index https://pypi.org/simple/
+pipx install pipx
+pipx ensurepath
+rmdir temp
+exit
+```
+
+To install this package, for every new python environment, run the following `pip` command:
 
 ```
-pip install artifacts-keyring
+pip install artifacts-keyring --index https://pypi.org/simple/
 ```
 
 ## Usage
+
+When using keyring via the CLI (provider `subprocess`) you MUST use `VssSessionToken` as the username component in the url.
+For the `import` provider that should not be required, unless a very old version of the `keyring` package is installed. 
 
 ### Requirements
 

--- a/src/artifacts_keyring/plugin.py
+++ b/src/artifacts_keyring/plugin.py
@@ -102,7 +102,8 @@ class CredentialProvider(object):
                 "-IsRetry", str(is_retry),
                 "-NonInteractive", str(non_interactive),
                 "-CanShowDialog", "False",
-                "-OutputFormat", "Json"
+                "-OutputFormat", "Json",
+                "-Verbosity", "Minimal"
             ],
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,


### PR DESCRIPTION
I implemented the `--keyring-provider` flag for Pip, after Pip was given the ability to query a `keyring` executable.
https://pip.pypa.io/en/stable/topics/authentication/#using-keyring-as-a-command-line-application
So I also wrote some documentation since it requires `VssSessionToken` to be used as the username component of the index url to work, which I currently only documented in github issues and our internal wiki.

---

Pip uses the entire output as the password. So currently when there is no PAT/JWT in the cache Pip will try a request with a password that starts with informative output stating which ADAL/MSAL provider is used. Requesting minimal output solves this.

---

~I'll have to rebase after #61 gets merged, but I just subscribed to it, so that shouldn't take long.~
