### PR TITLE
Don't write output to stdout

### DIFF
--- a/src/artifacts_keyring/plugin.py
+++ b/src/artifacts_keyring/plugin.py
@@ -115,8 +115,8 @@ class CredentialProvider(object):
         # from it for Device Flow authentication.
         for stderr_line in iter(proc.stderr.readline, b''):
             line = stderr_line.decode("utf-8", "ignore")
-            sys.stdout.write(line)
-            sys.stdout.flush()
+            sys.stderr.write(line)
+            sys.stderr.flush()
 
         proc.wait()
 


### PR DESCRIPTION
Writing output to stdout breaks the usage of artifacts-keyring with the keyring CLI since it is impossible to discriminate
between the output of the CLI and other text written to stdout.

See https://github.com/astral-sh/uv/issues/3260 as an example where this is an issue but note that this also affects using a system wide install of keyring as a backend with pip. 