### PR TITLE
Create 0.4.0rc0 pre-release version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = artifacts-keyring
-version = 0.3.5
+version = 0.4.0rc0
 author = Microsoft Corporation
 url = https://github.com/Microsoft/artifacts-keyring
 license_file = LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v1.1.1"
+    + "v1.2.0-alpha"
     + "/Microsoft.NuGet.CredentialProvider.tar.gz"
     )
 

--- a/src/artifacts_keyring/__init__.py
+++ b/src/artifacts_keyring/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "0.3.5"
+__version__ = "0.4.0rc0"
 
 import json
 import subprocess


### PR DESCRIPTION
Creating 0.4.0rc0 to pre-release [MI and SP Native Support ](https://github.com/microsoft/artifacts-credprovider/pull/492). 

To use the SP/MI feature, set the following env variable with the MI/SP client id. For SP there are additional fields to provide certificate information.

## Environment Variable
 `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS` 
```javascript
 {"endpointCredentials": [{"endpoint":"http://example.index.json", "clientId":"required", "clientCertificateSubjectName":"optional", "clientCertificateFilePath":"optional"}]}
```
- `endpoint`: required. Feed url to authenticate against. 
- `clientId`: required for both MI/SP. For user assigned managed identities enter the Entra client id. For system assigned variables set the value to `system`.  
- `clientCertificateSubjectName`: Subject Name of the certificate located in the My/ CurrentUser or LocalMachine certificate store. Optional field. Only used by SP authentication. 
- `clientCertificateFilePath`: File path location of the certificate on the machine. Optional field. Only used by SP authentication. 