### PR TITLE
Update to NetFx 4.8.1 CredentialProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use `artifacts-keyring` to set up authentication between `pip`/`twine` and Az
 * pip version **19.2** or higher
 * twine version **1.13.0** or higher
 * python version **3.0** or higher
-* .Net runtime 6.0.X or later is installed. Refer to [here](https://learn.microsoft.com/dotnet/core/install/) for installation guideline.
+* .Net runtime 8.0.X or later is installed. Refer to [here](https://learn.microsoft.com/dotnet/core/install/) for installation guideline.
 
 ### Publishing packages to an Azure Artifacts feed
 Once `artifacts-keyring` is installed, to publish a package, use the following `twine` command, replacing **<org_name>** and **<feed_name>** with your own:

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ import urllib.request
 
 CREDENTIAL_PROVIDER = (
     "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v1.2.3"
-    + "/Microsoft.NuGet.CredentialProvider.tar.gz"
+    + "v1.3.0"
+    + "/Microsoft.NetFx48.NuGet.CredentialProvider.tar.gz"
     )
 
 


### PR DESCRIPTION
Update the keyring wrapped to use the in support version of .NET Framework 4.8.1 rather than the deprecated 4.6.1 version.

DO NOT MERGE until release `1.3.0` is published for artifacts-credprovider.