### PR TITLE
Add .NET 8 support for v1.3.0 of credprovider

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ The `artifacts-keyring` package is layered on top of our [Azure Artifacts Creden
 - `ARTIFACTS_KEYRING_NONINTERACTIVE_MODE`: Controls whether the underlying credential provider can issue interactive prompts.
 - `ARTIFACTS_KEYRING_USE_NET8`: Controls whether or not to download the .NET 8 version of the Azure Artifacts Credential Provider.
 
+## Local development
+
+1. Install build dependencies with `pip install .`
+2. Build the project using `python -m build --outdir %DIRECTORY%`
+3. Open a new terminal window in `%DIRECTORY%`, then run `pip install ***.whl --force-reinstall`
+
 ## Contributing
 
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To use `artifacts-keyring` to set up authentication between `pip`/`twine` and Az
 * pip version **19.2** or higher
 * twine version **1.13.0** or higher
 * python version **3.0** or higher
-* .Net runtime 6.0.X or later is installed. Refer to [here](https://learn.microsoft.com/dotnet/core/install/) for installation guideline.
+* .NET runtime 8.0.X or later is installed. Refer to [here](https://learn.microsoft.com/dotnet/core/install/) for installation guideline.
 
 ### Publishing packages to an Azure Artifacts feed
 Once `artifacts-keyring` is installed, to publish a package, use the following `twine` command, replacing **<org_name>** and **<feed_name>** with your own:
@@ -52,6 +52,7 @@ The `artifacts-keyring` package is layered on top of our [Azure Artifacts Creden
 ### Environment variables
 
 - `ARTIFACTS_KEYRING_NONINTERACTIVE_MODE`: Controls whether the underlying credential provider can issue interactive prompts.
+- `ARTIFACTS_KEYRING_USE_NET8`: Controls whether or not to download the .NET 8 version of the Azure Artifacts Credential Provider.
 
 ## Contributing
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = artifacts-keyring
-version = 0.4.0
+version = 0.5.0
 author = Microsoft Corporation
 url = https://github.com/Microsoft/artifacts-keyring
 license_file = LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,10 @@ import tarfile
 import tempfile
 import urllib.request
 
-CREDENTIAL_PROVIDER = (
-    "https://github.com/Microsoft/artifacts-credprovider/releases/download/"
-    + "v1.2.3"
-    + "/Microsoft.NuGet.CredentialProvider.tar.gz"
-    )
-
+CREDENTIAL_PROVIDER_BASE = "https://github.com/Microsoft/artifacts-credprovider/releases/download/v1.3.0/"
+CREDENTIAL_PROVIDER_NETFX = CREDENTIAL_PROVIDER_BASE + "Microsoft.NuGet.CredentialProvider.tar.gz"
+CREDENTIAL_PROVIDER_NET8 = CREDENTIAL_PROVIDER + "Microsoft.Net8.NuGet.CredentialProvider.tar.gz"
+CREDENTIAL_PROVIDER_NET_VER_VAR_NAME = "ARTIFACTS_KEYRING_USE_NET8"
 
 def download_credential_provider(root):
     dest = os.path.join(root, "src", "artifacts_keyring", "plugins")
@@ -28,7 +26,7 @@ def download_credential_provider(root):
         os.makedirs(dest)
 
     print("Downloading and extracting to", dest)
-    with urllib.request.urlopen(CREDENTIAL_PROVIDER) as fileobj:
+    with urllib.request.urlopen(get_download_url(root)) as fileobj:
         tar = tarfile.open(mode="r|gz", fileobj=fileobj)
         tar.extractall(dest)
 
@@ -42,6 +40,12 @@ def get_version(root):
     m = re.search(r"__version__\s*=\s*['\"](.+?)['\"]", txt)
     return m.group(1) if m else "0.1.0"
 
+def get_download_url(root):
+    use_net_8 = CREDENTIAL_PROVIDER_NET_VER_VAR_NAME in os.environ and \
+        os.environ[CREDENTIAL_PROVIDER_NET_VER_VAR_NAME] and \
+        str(os.environ[CREDENTIAL_PROVIDER_NET_VER_VAR_NAME]).lower() == "true"
+
+    return CREDENTIAL_PROVIDER_NET8 if use_net_8 else CREDENTIAL_PROVIDER_NETFX
 
 if __name__ == "__main__":
     root = os.path.dirname(os.path.abspath(__file__))

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import urllib.request
 
 CREDENTIAL_PROVIDER_BASE = "https://github.com/Microsoft/artifacts-credprovider/releases/download/v1.3.0/"
 CREDENTIAL_PROVIDER_NETFX = CREDENTIAL_PROVIDER_BASE + "Microsoft.NuGet.CredentialProvider.tar.gz"
-CREDENTIAL_PROVIDER_NET8 = CREDENTIAL_PROVIDER + "Microsoft.Net8.NuGet.CredentialProvider.tar.gz"
+CREDENTIAL_PROVIDER_NET8 = CREDENTIAL_PROVIDER_BASE + "Microsoft.Net8.NuGet.CredentialProvider.tar.gz"
 CREDENTIAL_PROVIDER_NET_VER_VAR_NAME = "ARTIFACTS_KEYRING_USE_NET8"
 
 def download_credential_provider(root):
@@ -26,10 +26,11 @@ def download_credential_provider(root):
         os.makedirs(dest)
 
     print("Downloading and extracting to", dest)
-    with urllib.request.urlopen(get_download_url(root)) as fileobj:
+    download_url = get_download_url()
+    print("Downloading artifacts-credprovider from", download_url)
+    with urllib.request.urlopen(download_url) as fileobj:
         tar = tarfile.open(mode="r|gz", fileobj=fileobj)
         tar.extractall(dest)
-
 
 def get_version(root):
     src = os.path.join(root, "src", "artifacts_keyring", "__init__.py")
@@ -40,7 +41,7 @@ def get_version(root):
     m = re.search(r"__version__\s*=\s*['\"](.+?)['\"]", txt)
     return m.group(1) if m else "0.1.0"
 
-def get_download_url(root):
+def get_download_url():
     use_net_8 = CREDENTIAL_PROVIDER_NET_VER_VAR_NAME in os.environ and \
         os.environ[CREDENTIAL_PROVIDER_NET_VER_VAR_NAME] and \
         str(os.environ[CREDENTIAL_PROVIDER_NET_VER_VAR_NAME]).lower() == "true"

--- a/src/artifacts_keyring/__init__.py
+++ b/src/artifacts_keyring/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 import json
 import subprocess

--- a/src/artifacts_keyring/plugin.py
+++ b/src/artifacts_keyring/plugin.py
@@ -22,6 +22,8 @@ class CredentialProvider(object):
 
     def __init__(self):
         if sys.platform.startswith("win"):
+            # by default, attempt to search netfx plugins folder.
+            # if that doesn't exist, search netcore for newer credprovider versions.
             tool_path = os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),
                 "plugins",
@@ -30,6 +32,16 @@ class CredentialProvider(object):
                 "CredentialProvider.Microsoft",
                 "CredentialProvider.Microsoft.exe",
             )
+
+            tool_path = tool_path if os.path.exists(tool_path) else os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                "plugins",
+                "plugins",
+                "netcore",
+                "CredentialProvider.Microsoft",
+                "CredentialProvider.Microsoft.exe",
+            )
+
             self.exe = [tool_path]
         else:
             try:
@@ -56,7 +68,6 @@ class CredentialProvider(object):
 
         if not os.path.exists(tool_path):
             raise RuntimeError("Unable to find credential provider in the expected path: " + tool_path)
-
 
     def get_credentials(self, url):
         # Public feed short circuit: return nothing if not getting credentials for the upload endpoint


### PR DESCRIPTION
Add .NET 8 support for v1.3.0 of [artifacts-credprovider](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.3.0). 

To avoid breaking existing customers before a major release which removes support for the end of support .NET versions, allow users to install .NET 8 via the `ARTIFACTS_KEYRING_USE_NET8` environment variable.