### PR TITLE
Use OS trustore for certificate resolution

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*
 install_requires =
     keyring >= 16.0
     requests >= 2.20.0
+    truststore >= 0.10.0
 
 [options.packages.find]
 where=src

--- a/src/tests/test_backend.py
+++ b/src/tests/test_backend.py
@@ -82,13 +82,13 @@ def validating_provider(monkeypatch):
     def mock_get_credentials(self, url, is_retry):
         return url, is_retry
 
-    def mock_requests_get(url, auth):
+    def mock_requests_get(self, url, **kwargs):
         response = MockGetResponse()
         response.status_code = int(url[:3])
         return response
 
     monkeypatch.setattr(CredentialProvider, "_get_credentials_from_credential_provider", mock_get_credentials)
-    monkeypatch.setattr(requests, "get", mock_requests_get)
+    monkeypatch.setattr(requests.Session, "get", mock_requests_get)
 
     yield CredentialProvider()
 


### PR DESCRIPTION
I am sitting behind a proxy inside of a corporate environment. To access any remote website, I have to use the system truststore. This PR adds this feature to the package using the [truststore](https://github.com/sethmlarson/truststore) package. This should also resolve #83 