### PR TITLE
Default CanShowDialog to true

### DIFF
--- a/src/artifacts_keyring/plugin.py
+++ b/src/artifacts_keyring/plugin.py
@@ -113,7 +113,7 @@ class CredentialProvider(object):
                 "-Uri", url,
                 "-IsRetry", str(is_retry),
                 "-NonInteractive", str(non_interactive),
-                "-CanShowDialog", "False",
+                "-CanShowDialog", "True",
                 "-OutputFormat", "Json"
             ],
             stdin=subprocess.PIPE,


### PR DESCRIPTION
- CanShowDialog should be defaulted to true for the reasons outlined in https://github.com/NuGet/Home/issues/14010
- If a system does not have the requirements to pop up a dialog (no browser support) the credprovider will fall through to device code flow.

see #82 