### PR TITLE
steup.cfg python_requires table fix

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,15 +29,14 @@ package_dir=
 packages = find_namespace:
 include_package_data = True
 zip_safe = False
-
-[options.package_data]
-artifacts_keyring =
-    plugins/**/*
-
 python_requires = >=3.9
 install_requires =
     keyring >= 16.0
     requests >= 2.20.0
+
+[options.package_data]
+artifacts_keyring =
+    plugins/**/*
 
 [options.packages.find]
 where=src


### PR DESCRIPTION
cibuildwheel was not respecting the python_requires field since it was under options.package_data, update this to the correct options.