### PR TITLE
re-enable repair command for manylinux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,5 +26,3 @@ archs = ["x86_64", "aarch64"]
 skip = ["*-manylinux_i686", "*-manylinux2014_i686", "*-musllinux*"]
 manylinux-x86_64-image = "manylinux2014"
 manylinux-aarch64-image = "manylinux2014"
-# avoid running repair on linux because we package self-contained binaries explicitly
-repair-wheel-command = ""

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ include_package_data = True
 zip_safe = False
 python_requires = >=3.9
 install_requires =
-    keyring >= 16.0
+    keyring >= 22.0
     requests >= 2.20.0
 
 [options.package_data]


### PR DESCRIPTION
PyPi will block distribution for non-manylinux* wheels, re-enable the repair command to re-package the Linux binaries.