### PR TITLE
Release 1.0.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 0
 
 [metadata]
 name = artifacts-keyring
-version = 1.0.0rc1
+version = 1.0.0
 author = Microsoft Corporation
 url = https://github.com/Microsoft/artifacts-keyring
 license = "MIT"

--- a/src/artifacts_keyring/__init__.py
+++ b/src/artifacts_keyring/__init__.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import
 
 __author__ = "Microsoft Corporation <python@microsoft.com>"
-__version__ = "1.0.0rc1"
+__version__ = "1.0.0"
 
 import warnings
 from .support import urlsplit


### PR DESCRIPTION
## 1.0.0 release
This pull request finalizes the release of version 1.0.0

### 1.0.0 Announcement: #90

> 🔧 What’s New In v1.0.0 🔧
> Removal of Python 2 Support
> Python 2 reached its end of support on [January 1, 2020](https://devguide.python.org/versions/) but 2.7 was still supported by artifacts-keyring. With this major release, we'll be requiring a Python version >=3.9 which is the minimum version that has not reached its end of support.
> 
> Platform Specific  #Python
> A major revision on how we publish the artifacts-keyring package will be coming, where we will now be using the [cibuildwheel](https://cibuildwheel.pypa.io/) tooling to publish pre-built .whls for all of our supported ecosystems win-x64, osx-x64,osx-arm64,linux-x64,linux-arm64.
> 
> No .NET runtime required by default
> With [release 1.4.1 of artifacts-credprovider](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.4.1), self-contained binaries have now been published for the artifacts-credprovider plugin used by our keyring. By combining these binaries with the new platform specific distros, users on machines without .NET previously installed will be able to get running with a simple pip install artifacts-keyring command. This is especially valuable for CI environments where a .NET requirement adds extra overhead.
> 
> When a supported environment and Python tag is not found, pip tooling will install the sdist which does not include self-contained binaries and will require a corresponding .NET runtime.

Relevant issues: #97 #86 #89 #87