### PR TITLE
Set executable permissions at build time instead of runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,21 @@ if __name__ == "__main__":
         print("Removing libcoreclrtraceptprovider.so from plugins directory")
         os.remove(clr_trace_path)
 
+    # Set executable permissions on the credential provider binary at build time.
+    # This ensures the binary is already executable when packaged into the wheel,
+    # avoiding the need for os.chmod at runtime (which fails for restricted users).
+    # See https://github.com/microsoft/artifacts-keyring/issues/99
+    cred_provider_exe = os.path.join(
+        dest,
+        "plugins",
+        "netcore",
+        "CredentialProvider.Microsoft",
+        "CredentialProvider.Microsoft",
+    )
+    if os.path.exists(cred_provider_exe):
+        print("Setting executable permissions on", cred_provider_exe)
+        os.chmod(cred_provider_exe, 0o755)
+
     setup(
         version=get_version(root),
         cmdclass={

--- a/src/artifacts_keyring/plugin.py
+++ b/src/artifacts_keyring/plugin.py
@@ -39,15 +39,6 @@ class CredentialProvider(object):
             # not be self-contained (i.e. may require a .NET runtime to be installed)
             if os.path.exists(self._PLUGINS_ROOT):
                 exe_path = os.path.join(self._PLUGINS_ROOT, 'CredentialProvider.Microsoft')
-                try:
-                    if os.path.exists(exe_path):
-                        os.chmod(exe_path, 0o755)
-                except Exception as e:
-                    raise RuntimeError(
-                        "Failed to set executable permissions for the Credential Provider at "
-                        + self._PLUGINS_ROOT
-                        + ". Error: " + str(e)
-                    )
 
                 # If the directory contains a runtimes folder, the binary is not
                 # self-contained and requires a .NET install to run.


### PR DESCRIPTION
Move os.chmod of CredentialProvider.Microsoft binary from plugin.py (runtime) to setup.py (build time). This ensures the binary is already executable when packaged into the wheel, so restricted users who cannot chmod files they don't own no longer encounter permission errors.

Fixes https://github.com/microsoft/artifacts-keyring/issues/99